### PR TITLE
Fix extension.js to allow json updates.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -175,7 +175,7 @@ function PreviewSwaggerController(swag) {
         var editor = vscode.window.activeTextEditor;
         if (!editor) { return; }
         var doc = editor.document;
-        if (doc.languageId === "yaml") {
+        if (doc.languageId === "yaml" || doc.languageId === "json") {
             swag.update();
         } else {
             swag.close();


### PR DESCRIPTION
Allows the controller to update the preview when the active document is a json (swagger) file.