### PR TITLE
Issue 18 - add support for standard yml extension

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -180,7 +180,7 @@ function GetParsedFile(fileName, fileContent) {
         return JSON.parse(fileContent);
     }
 
-    if (extension == "yaml") {
+    if (extension == "yaml" || extension == "yml") {
         return YAML.parse(fileContent);
     }
 }


### PR DESCRIPTION
Very minor change to add support for the `yml` extension in addition to `yaml`.

Resolves #18 