### PR TITLE
Support extensions other than json and yaml

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -174,12 +174,12 @@ function activate(context) {
 }
 
 function GetParsedFile(fileName, document) {
+    fileContent = document.getText();
     if (document.languageId === "json") {
         return JSON.parser(fileContent);
     } else if (document.languageId === "yaml") {
         return YAML.parse(fileContent);
     } else if (document.languageId === "plaintext") {
-        fileContent = document.getText();
         if (fileContent.match(/^\s*[{[]/)) {
             return JSON.parser(fileContent);
         } else {

--- a/extension.js
+++ b/extension.js
@@ -174,7 +174,7 @@ function activate(context) {
 }
 
 function GetParsedFile(fileName, document) {
-    fileContent = document.getText();
+    var fileContent = document.getText();
     if (document.languageId === "json") {
         return JSON.parser(fileContent);
     } else if (document.languageId === "yaml") {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   ],
   "activationEvents": [
     "onLanguage:yaml",
-    "onLanguage:json"
+    "onLanguage:json",
+    "onLanguage:plaintext"
   ],
   "main": "./extension",
   "contributes": {


### PR DESCRIPTION
At my company we are using swagger as our file extension and not yaml. This change allows file types of plaintext to still be previewed as swagger files. 

Further it checks the language id instead of the file extensions which should resolve files called yml instead of yaml.