### PR TITLE
Support customize default host(instead of localhost).

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ OR
 
 Default port of the preview url can be changed by changing the `swaggerViewer.defaultPort` value in `User/Workspace Settings`
 
+### Change Default Host
+
+Default host(localhost) of the preview url can be changed by changing the `swaggerViewer.defaultHost` value in `User/Workspace Settings`
+
 ## Validation (Partial)
 
 Swagger Viewer validates your documents against Swagger 2.0 and OpenAPI specifications. If there are any issues it will be shown as a warning in the problems panel. Right now only one validation error will be shown even if there are multiple issues.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,11 @@
 			"type": "object",
 			"title": "Swagger Viewer configuration",
 			"properties": {
+				"swaggerViewer.defaultHost": {
+					"type": "string",
+					"default": "localhost",
+					"description": "Default host in which the preview should be opened."
+				},
 				"swaggerViewer.defaultPort": {
 					"type": "integer",
 					"default": 9000,

--- a/src/preview/server.ts
+++ b/src/preview/server.ts
@@ -5,12 +5,15 @@ import * as express from 'express';
 import * as http from 'http';
 import * as socketio from 'socket.io';
 
+const SERVER_HOST = vscode.workspace.getConfiguration('swaggerViewer').defaultHost || 'localhost';
+
 const SERVER_PORT = vscode.workspace.getConfiguration('swaggerViewer').defaultPort || 9000;
 
 const FILE_CONTENT: { [key: string]: any } = {};
 
 export class PreviewServer {
 
+	currentHost: string = SERVER_HOST
 	currentPort: number = SERVER_PORT
 	io: socketio.Server
 	server: http.Server
@@ -65,7 +68,7 @@ export class PreviewServer {
 	}
 
 	getUrl(fileHash: string): string {
-		return `http://localhost:${this.currentPort}/${fileHash}`;
+		return `http://${this.currentHost}:${this.currentPort}/${fileHash}`;
 	}
 
 	stop(){


### PR DESCRIPTION
For the specific project in the real word, for the security issues, we have the need that how to customize both host and post  So I think It may be helpful for another. Thank you ;)

Ex: It's **lozi.local**:port in my case.