### PR TITLE
changes default port

### DIFF
--- a/src/preview/server.ts
+++ b/src/preview/server.ts
@@ -8,7 +8,7 @@ import * as SwaggerParser from 'swagger-parser';
 
 const SERVER_HOST = vscode.workspace.getConfiguration('swaggerViewer').defaultHost || 'localhost';
 
-const SERVER_PORT = vscode.workspace.getConfiguration('swaggerViewer').defaultPort || 9000;
+const SERVER_PORT = vscode.workspace.getConfiguration('swaggerViewer').defaultPort || 15870;
 
 const FILE_CONTENT: { [key: string]: any } = {};
 


### PR DESCRIPTION
Fixes #37 

The port I picked for the new default is just a random number I generated between 10,000 and 20,000.

I think the related issue articulates the problem well, but to restate: having the default port be a number that is relatively likely to collide with an already-in-use port or to block another application from using port 9000 is frustrating for a dev tool. While it is possible to configure a new default port in the settings, I'm not sure there's a compelling reason to leave the default as 9000.

I'm not clear if the default port value is referenced anywhere other than this file; if that's the case, additional code changes might be needed. I couldn't find anything looking over the code myself.