### PR TITLE
Support vscode remote extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	"version": "3.0.1",
 	"publisher": "Arjun",
 	"engines": {
-		"vscode": "^1.34.0"
+		"vscode": "^1.40.0"
 	},
 	"extensionDependencies": [
 		"redhat.vscode-yaml"

--- a/src/preview/client.ts
+++ b/src/preview/client.ts
@@ -157,11 +157,16 @@ export async function activate(context: vscode.ExtensionContext) {
         const previewInBrowser: boolean = !!vscode.workspace.getConfiguration(
           "swaggerViewer"
         ).previewInBrowser;
+
+        // Make the port available locally and get the full URI
+        const previewUrl = await vscode.env.asExternalUri(
+            vscode.Uri.parse(previewServer.getUrl(fileHash)));
+
         if (previewInBrowser) {
-          new BrowserPreview(previewServer.getUrl(fileHash), fileName);
+          new BrowserPreview(previewUrl.toString(), fileName);
         } else {
           let inlinePreview = new InlinePreview(
-            previewServer.getUrl(fileHash),
+            previewUrl.toString(),
             fileName
           );
           context.subscriptions.push(inlinePreview.disposable);


### PR DESCRIPTION
Set up automatic port forwarding using `vscode.env.asExternalUri` to get the browser URL.

See https://code.visualstudio.com/api/advanced-topics/remote-extensions#forwarding-localhost