### PR TITLE
Avoid npm run vscode:prepublish failure

### DIFF
--- a/src/preview/client.ts
+++ b/src/preview/client.ts
@@ -96,7 +96,7 @@ export async function activate(context: vscode.ExtensionContext) {
       (uri) => {
         for (let document of vscode.workspace.textDocuments) {
           if (document.uri.toString() === uri) {
-            const parsedYAML = YAML.safeLoad(document.getText());
+            const parsedYAML = <any>YAML.safeLoad(document.getText());
             if (parsedYAML) {
               if (parsedYAML.swagger === "2.0") {
                 return "swaggerviewer:swagger";


### PR DESCRIPTION
Add a type coercion to `any` to make sure that the returned YAML object is not strictly checked.

Closes #93