### PR TITLE
Route requests through local proxy with CORS

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
 		"express": "^4.17.1",
 		"js-yaml": "^3.13.1",
 		"portfinder": "^1.0.26",
+		"request": "^2.88.2",
 		"socket.io": "^2.3.0",
 		"swagger-parser": "^9.0.1",
 		"swagger-ui-dist": "^3.25.2"

--- a/src/preview/server.ts
+++ b/src/preview/server.ts
@@ -5,6 +5,7 @@ import * as express from "express";
 import * as http from "http";
 import * as socketio from "socket.io";
 import * as SwaggerParser from "swagger-parser";
+import * as request from "request";
 import { getPortPromise } from "portfinder";
 
 const SERVER_PORT =
@@ -34,6 +35,10 @@ export class PreviewServer {
       "/node_modules",
       express.static(path.join(__dirname, "..", "..", "node_modules"))
     );
+    app.use('/proxy', (req, res) => {
+      res.header("Access-Control-Allow-Origin", "*");
+      request(req.query.url).pipe(res);
+    });
     app.use("/:fileHash", (req, res) => {
       let htmlContent = fs
         .readFileSync(path.join(__dirname, "..", "..", "static", "index.html"))

--- a/static/index.html
+++ b/static/index.html
@@ -101,6 +101,10 @@
 				plugins: [
 					SwaggerUIBundle.plugins.DownloadUrl
 				],
+				requestInterceptor: function (req) {
+					return new Request(`${window.location.origin}/proxy?url=${encodeURIComponent(req.url)}`, req)
+				},
+				showMutatedRequest: false,
 				layout: "StandaloneLayout"
 			})
 


### PR DESCRIPTION
Because VSCode has no intention of changing their stance on requires CORS headers to work in webviews https://github.com/microsoft/vscode/issues/72900 -- the only workaround I see is using a proxy service like http://www.whateverorigin.org/ which just proxies requests and adds CORS headers.

Fortunately this app is in a unique place in that it's *already running* a webserver. So we can use that same server to proxy requests and add CORS. This is pretty easy with SwaggerUIBundle's `requestInterceptor` config argument which takes a function for altering requests.

Thus this PR does two things:

- add a `/proxy` endpoint to the server which takes a query param `url` with the actual URL. use `request` library to forward the entire request object to that url. Add CORS to the response and return it.
- add `requestInterceptor` argument to `SwaggerUIBundle` to change the url to use the backend's `/proxy?url=...`

The result -- no need to worry about CORS, the UI works the same.

Fixes #30 
Fixes #23 